### PR TITLE
Updated path for puphpet VM location

### DIFF
--- a/data/config/common.yml-dist
+++ b/data/config/common.yml-dist
@@ -6,7 +6,7 @@ protobox:
 vagrant:
   vm:
     box: ubuntu-precise12042-x64-vbox43
-    box_url: 'https://puphpet.s3.amazonaws.com/ubuntu-precise12042-x64-vbox43.box'
+    box_url: 'http://box.puphpet.com/ubuntu-precise12042-x64-vbox43.box'
     hostname: protobox
     network:
       private_network: 192.168.5.10


### PR DESCRIPTION
The puphpet site got a big bill for their Amazon storage. They have moved their Vagrant VMs - see note below:  ref: https://puphpet.com/

ATTN: If you previously created a PuPHPet box and now Vagrant is complaining about not being able to download the box you chose, or that the box is corrupt, please update box URLs within Vagrantfile and common.yaml! I received a scary bill from AWS S3 and had to find a new host. Thanks to my buddies at Pressable for donating space and bandwidth! All box URLs have been changed from https://puphpet.s3.amazonaws.com/* to http://box.puphpet.com/*.
