### PR TITLE
Remove which -s switch from ansible bootstrap

### DIFF
--- a/ansible/shell/bootstrap
+++ b/ansible/shell/bootstrap
@@ -96,7 +96,7 @@ end
 def git
   @git ||= if ENV['GIT'] and File.executable? ENV['GIT']
     ENV['GIT']
-  elsif Kernel.system '/usr/bin/which -s git'
+  elsif Kernel.system '/usr/bin/which git'
     'git'
   else
     s = `xcrun -find git 2>/dev/null`.chomp


### PR DESCRIPTION
When running the installation script on a linux machine `Debian GNU/Linux 7 (wheezy)`

```
Illegal option -s
Usage: /usr/bin/which [-a] args
Git is required
```

The `which -s` switch seems to be only available on OSX machines.

Removing the -s switch entirely seems to fix this issue.
