### PR TITLE
Update .gitattribute with lf EOL for windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 # Autodetect text files
-* text=auto eol=lf
+* text=auto
+
+# Make sure unix shell scripts use the correct line endings
+*.sh eol=lf
 
 # ...Unless the name matches the following
 # overriding patterns


### PR DESCRIPTION
Windows had some conflicts with eol if they have set them to auto crlf in the global config.

Although Vagrant will automagically replace these with linefeeds when running through shell, they will not replace them in scripts that are subsequently called from within another. os-detect is used in this way and fails on windows machines with unknown command \r.

This should fix this.
