### PR TITLE
Use the `host` property specified for each db in the config

### DIFF
--- a/lib/ansible/roles/mariadb/tasks/users.yml
+++ b/lib/ansible/roles/mariadb/tasks/users.yml
@@ -60,6 +60,7 @@
   mysql_user: >
     name={{ item.user }}
     password={{ item.password }}
+    host={{ item.host }}
     priv=*.*:{{ item.grant|join(',') }}
     state=present
   with_items: mariadb.databases

--- a/lib/ansible/roles/mysql/tasks/users.yml
+++ b/lib/ansible/roles/mysql/tasks/users.yml
@@ -60,6 +60,7 @@
   mysql_user: >
     name={{ item.user }}
     password={{ item.password }}
+    host={{ item.host }}
     priv=*.*:{{ item.grant|join(',') }}
     state=present
   with_items: mysql.databases


### PR DESCRIPTION
This allows a user to be restricted to any host desired, rather than just 'localhost'.
