### PR TITLE
Add accept_hostkey=yes to git tasks

### DIFF
--- a/lib/ansible/applications/pyrocms/tasks/application.yml
+++ b/lib/ansible/applications/pyrocms/tasks/application.yml
@@ -18,6 +18,7 @@
     repo={{ item.0.options.source|default('git@github.com:pyrocms/pyrocms.git') }}
     dest={{ item.0.path }}
     version={{ item.0.options.version|default('master') }}
+    accept_hostkey=yes
   with_together:
     - applications.pyrocms
     - pyrocms_install.results 

--- a/lib/ansible/applications/repository/tasks/git.yml
+++ b/lib/ansible/applications/repository/tasks/git.yml
@@ -30,6 +30,7 @@
     repo={{ item.options.source }}
     dest={{ item.path }}
     version={{ item.options.revision|default('master') }}
+    accept_hostkey=yes
   with_items: applications.repository
   when: item.install == 1 and item.options.provider is defined and item.options.provider == 'git'
 

--- a/lib/ansible/applications/sylius/tasks/application.yml
+++ b/lib/ansible/applications/sylius/tasks/application.yml
@@ -27,6 +27,7 @@
     repo={{ item.0.options.source|default('git@github.com:Sylius/Sylius.git') }}
     dest={{ item.0.path }}
     version={{ item.0.options.revision|default('master') }}
+    accept_hostkey=yes
   with_together:
     - applications.sylius
     - sylius_install.results 

--- a/lib/ansible/applications/symfony/tasks/application.yml
+++ b/lib/ansible/applications/symfony/tasks/application.yml
@@ -27,6 +27,7 @@
     repo={{ item.0.options.source|default('git@github.com:symfony/symfony-standard.git') }}
     dest={{ item.0.path }}
     version={{ item.0.options.revision|default('master') }}
+    accept_hostkey=yes
   with_together:
     - applications.symfony
     - symfony_install.results 

--- a/lib/ansible/applications/wordpress/tasks/application.yml
+++ b/lib/ansible/applications/wordpress/tasks/application.yml
@@ -43,6 +43,7 @@
     repo={{ item.options.repo|default(wordpress_repo) }}
     dest={{ item.path }}
     version={{ item.options.revision|default(item.options.version) }}
+    accept_hostkey=yes
   with_items: applications.wordpress
   when: item.install == 1 and item.options.method is defined and item.options.method == 'git'
 

--- a/lib/ansible/roles/server/tasks/dotfiles.yml
+++ b/lib/ansible/roles/server/tasks/dotfiles.yml
@@ -2,6 +2,7 @@
   git: >
     repo={{ server.dotfiles.repo }}
     dest={{ server.dotfiles.repo_path|default(ansible_env.HOME) }}
+    accept_hostkey=yes
   when: server.dotfiles.repo is defined
 
 # check for vimrc if we are not in the root folder to symlink


### PR DESCRIPTION
Made the changes as discussed in #82 but believe it causes `/root/.ssh/ does not exist`

Minimal config created with protobox-web. Only thing changed is `ssh: forward_agent: true`
https://gist.github.com/9579267

```
$ vagrant destroy
$ vagrant up
```

```
TASK: [repository | git | install git application] ****************************
failed: [localhost] => (item={'path': '/srv/www/web/test', 'name': 'repo-test', 'install': 1, 'options': {'pre_install': [], 'source': 'git@bitbucket.org:JDorman/test.git', 'provider': 'git', 'post_install': [], 'revision': 'master'}}) => {"failed": true, "item": {"install": 1, "name": "repo-test", "options": {"post_install": [], "pre_install": [], "provider": "git", "revision": "master", "source": "git@bitbucket.org:JDorman/test.git"}, "path": "/srv/www/web/test"}}
msg: /root/.ssh/ does not exist
```
