### PR TITLE
Update Apache with vhost capabilities.

### DIFF
--- a/lib/ansible/roles/apache/templates/default.conf.j2
+++ b/lib/ansible/roles/apache/templates/default.conf.j2
@@ -30,6 +30,17 @@
     ErrorLog /var/log/apache2/error.log
     CustomLog /var/log/apache2/access.log combined
 
+    {% if item.aliases is defined %}{% for alias in item.aliases %}
+    Alias{% if alias.match %}Match{% endif %} {{ alias.source }} {{ alias.target }}
+    <Directory {{ alias.target }}>
+        Options Indexes FollowSymLinks MultiViews
+        #AllowOverride None
+        AllowOverride All
+        Order allow,deny
+        allow from all
+    </Directory>
+    {% endfor %}{% endif %}
+
     {% if item.setenv is defined %}{% for env in item.setenv %}
     SetEnv {{ env }}
     {% endfor %}{% endif %}


### PR DESCRIPTION
This updates protobox to allow for aliases within the config of each vhost.

Syntax would be similar to the following:

``` yaml

---
apache:
  install: 1
  modules:
    - rewrite
  user: vagrant
  group: www-data
  default_vhost: false
  mpm_module: prefork
  vhosts:
    -
      name: lemonstand
      servername: lemonstand.dev
      serveraliases:
        - www.lemonstand.dev
      docroot: /srv/www/web/lemonstand
      port: 80
      setenv:
        - 'APP_ENV dev'
      override:
        - All
      aliases:
        -
          match: 1
          source: '^/modules/(?!shop.*)(?!session.*)(?!oolemonstandbox.*)(?!core.*)(?!cms.*)(?!blog.*)(?!backend.*)(?!users.*)(?!system.*)(.*)'
          target: '/srv/www/web/modules/$1'
        -
          match: 0
          source: '/themes/'
          target: '/srv/www/web/themes/'
```

Offers both `Alias` and `AliasMatch` compatibility. Also adds a directory with the same contents as the docroot.

> PR created with http://hub.github.com/
> Hopefully this works!
