### PR TITLE
Show that the channels key exists.

### DIFF
--- a/data/config/common.yml-dist
+++ b/data/config/common.yml-dist
@@ -156,6 +156,7 @@ php:
     - php5-gd
   pear:
     install: 1
+    channels: [ ]
     modules: [ ]
   pecl:
     install: 1


### PR DESCRIPTION
I had to go fishing to find out how to add a channel to PEAR (I wanted to install Drush that way instead of via a dummy Drupal installation).

...although actually there seems to be some problems with it. Maybe that's why you didn't include it? It seems to try discovering channels twice on a re-provision. Let me dig in for a couple minutes and see if I can spot the issue...

That'll be a separate PR in any case.
