### PR TITLE
Update Wordpress install to handle additional config values.

### DIFF
--- a/lib/ansible/applications/wordpress/templates/wp-config.php.j2
+++ b/lib/ansible/applications/wordpress/templates/wp-config.php.j2
@@ -82,3 +82,13 @@ if ( !defined('ABSPATH') )
 
 /** Sets up WordPress vars and included files. */
 require_once(ABSPATH . 'wp-settings.php');
+
+{% if item.0.options.config is defined %}
+/**
+ * Custom configuration
+ * {{ ansible_managed }}
+ */
+{% for config, value in item.0.options.config.iteritems() %}
+define('{{ config | upper }}', {{ value|to_nice_json }});
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
This change updates the wordpress application template to process another entry in the config under `wordpress.options`

This allows you to add additional configuration fields directly to the wp-config template from your yaml config.

An example would be below:

```
applications:
  install: 1
  wordpress:
    - name: test
      install: 1
      path: /srv/www/web/wordpress
      options:
        version: '3.6'
        sha: 'cf3dac69cd1810d8f4880b2c982fee869a0c56e1c4f793bbfc6d7021fd6da97c'
        revision: 'master'
        method: zip
        dbhost: localhost
        dbname: wordpress
        dbuser: root
        dbpass: root
        config:
          wp_home : 'http://build.wordpress-develop.dev'
          wp_siteurl : 'http://build.wordpress-develop.dev'
          wp_debug: true
```

This allows you to set and override some of the settings you might need when importing a database or other website while still following the recommendation of .gitignores to ignore the wp-config file in your repository.

Added config processing to wp-config
