### PR TITLE
Implementation of the owner and group for apache on debian based systems.

### DIFF
--- a/lib/ansible/roles/apache/tasks/apache.yml
+++ b/lib/ansible/roles/apache/tasks/apache.yml
@@ -24,6 +24,24 @@
   notify:
     - apache-restart
 
+- name: apache | apache2 lock
+  file: >
+    path=/var/lock/apache2
+    owner={{ apache.user }}
+    group={{ apache.group }}
+    mode=0755
+
+- name: apache | set envvars
+  template: >
+    src=envvars.j2
+    dest=/etc/apache2/envvars
+    owner=root
+    group=root
+    mode=0644
+  notify:
+    - apache-restart
+  when: ansible_os_family == 'Debian'
+
 - name: apache | install apache modules
   command: a2enmod {{ item }}
   with_items: apache.modules

--- a/lib/ansible/roles/apache/templates/envvars.j2
+++ b/lib/ansible/roles/apache/templates/envvars.j2
@@ -1,0 +1,36 @@
+# {{ ansible_managed }}
+# envvars - default environment variables for apache2ctl
+
+# this won't be correct after changing uid
+unset HOME
+
+# for supporting multiple apache2 instances
+if [ "${APACHE_CONFDIR##/etc/apache2-}" != "${APACHE_CONFDIR}" ] ; then
+  SUFFIX="-${APACHE_CONFDIR##/etc/apache2-}"
+else
+  SUFFIX=
+fi
+
+# Since there is no sane way to get the parsed apache2 config in scripts, some
+# settings are defined via environment variables and then used in apache2ctl,
+# /etc/init.d/apache2, /etc/logrotate.d/apache2, etc.
+export APACHE_RUN_USER={{ apache.user | default('www-data') }}
+export APACHE_RUN_GROUP={{ apache.group | default('www-data') }}
+export APACHE_PID_FILE=/var/run/apache2$SUFFIX.pid
+export APACHE_RUN_DIR=/var/run/apache2$SUFFIX
+export APACHE_LOCK_DIR=/var/lock/apache2$SUFFIX
+# Only /var/log/apache2 is handled by /etc/logrotate.d/apache2.
+export APACHE_LOG_DIR=/var/log/apache2$SUFFIX
+
+## The locale used by some modules like mod_dav
+export LANG=C
+## Uncomment the following line to use the system default locale instead:
+#. /etc/default/locale
+
+export LANG
+
+## The command to get the status for 'apache2ctl status'.
+## Some packages providing 'www-browser' need '--dump' instead of '-dump'.
+#export APACHE_LYNX='www-browser -dump'
+
+umask 0007


### PR DESCRIPTION
This fixes issue #138 which I mentioned there are file permission issues and later discovered that the owner and group values in the config weren't being used anywhere. 

They are being used now and Apache and by relation PHP are now running with the user group permissions in the config.
