### PR TITLE
Ignore failure of 'logs | link logs to vagrant folder'

### DIFF
--- a/lib/ansible/roles/server/tasks/logs.yml
+++ b/lib/ansible/roles/server/tasks/logs.yml
@@ -3,3 +3,4 @@
     src=/var/log
     dest=/vagrant/logs
     state=link
+  ignore_errors: yes


### PR DESCRIPTION
During provisioning with a windows host, the failure of the log symlink causes an abort. This failure is likely due to SMB shares being used for the shared folders. The symlink isn't crucial to the working of the virtual machine, and the logs are still accessible via `vagrant ssh` if the line fails.
