### PR TITLE
Add keys, required by RVM 1.2.6+

### DIFF
--- a/lib/ansible/roles/php/tasks/mailcatcher.yml
+++ b/lib/ansible/roles/php/tasks/mailcatcher.yml
@@ -7,7 +7,9 @@
     - libsqlite3-dev
 
 - name: mailcatcher | install RVM 
-  shell: \curl -L https://get.rvm.io | bash -s stable --ruby
+  shell: >
+    gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3 &&
+    \curl -L https://get.rvm.io | bash -s stable --ruby
 
 - name: mailcatcher | install mailcatcher
   shell: /usr/local/rvm/bin/rvm default@mailcatcher --create do gem install mailcatcher --no-rdoc --no-ri


### PR DESCRIPTION
RVM 1.2.6+ introduced signature checking (https://github.com/wayneeseguin/rvm/issues/3110)
The 'vagrant up' and 'vagrant provision' commands fail due this.

Adding the line below before install RVM (on mailcatcher installation) solves the issue:

```
gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
```
