### PR TITLE
Improving the installation status verification when installing Console_Table pear module dependency for Drush

### DIFF
--- a/lib/ansible/applications/drupal/tasks/drush.yml
+++ b/lib/ansible/applications/drupal/tasks/drush.yml
@@ -11,6 +11,9 @@
 - name: drush | install console table
   command: >
     pear install Console_Table
+  register: pear_result
+  changed_when: "'already installed' not in pear_result.stdout"
+  failed_when: "'already installed' not in pear_result.stdout and 'install ok' not in pear_result.stdout and pear_result.stderr"
 
 #- name: drush | install drush version
 #  command: >


### PR DESCRIPTION
When the Drupal application is enabled, protobox tries to install Console_Table pear module, but when doing a 'vagrant provision', it fails, saying that the Console_Table is already installed.
This fix improves this installation verification, checking when Console_Table installation status should be treated as an error.
